### PR TITLE
Fix issue when parsing large CPU Masks (+32C) systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lrita/numa
+module github.com/benjojo/numa
 
 go 1.12
 

--- a/numa_linux_test.go
+++ b/numa_linux_test.go
@@ -50,4 +50,9 @@ func TestCPUMaskParse(t *testing.T) {
 	if cpumask3.String() != "00000000FFFFFFFF,00000000FFFFFFFF" {
 		t.Fatalf("Failed to parse CPU Mask 3 correctly, Expected %v but got %v", "00000000FFFFFFFF,00000000FFFFFFFF", cpumask3.String())
 	}
+
+	cpumask4 := parseCPUMapMask("0003ff,f0003fff", 32, 64)
+	if cpumask4.String() != "000003FFF0003FFF" {
+		t.Fatalf("Failed to parse CPU Mask 4 correctly, Expected %v but got %v", "000003FFF0003FFF", cpumask4.String())
+	}
 }

--- a/numa_linux_test.go
+++ b/numa_linux_test.go
@@ -34,3 +34,20 @@ func TestCPUAndNodeShow(t *testing.T) {
 		t.Log(fmt.Sprintf("node %d cpus: %s", node, strings.Join(cpu, " ")))
 	}
 }
+
+func TestCPUMaskParse(t *testing.T) {
+	cpumask1 := parseCPUMapMask("000f,ff000fff", 32, 64)
+	if cpumask1.String() != "0000000FFF000FFF" {
+		t.Fatalf("Failed to parse CPU Mask 1 correctly, Expected %v but got %v", "0000000FFF000FFF", cpumask1.String())
+	}
+
+	cpumask2 := parseCPUMapMask("fff0,00fff000", 32, 64)
+	if cpumask2.String() != "0000FFF000FFF000" {
+		t.Fatalf("Failed to parse CPU Mask 2 correctly")
+	}
+
+	cpumask3 := parseCPUMapMask("00000000,00000000,00000000,00000000,00000000,ffffffff,00000000,ffffffff", 32, 128)
+	if cpumask3.String() != "00000000FFFFFFFF,00000000FFFFFFFF" {
+		t.Fatalf("Failed to parse CPU Mask 3 correctly, Expected %v but got %v", "00000000FFFFFFFF,00000000FFFFFFFF", cpumask3.String())
+	}
+}


### PR DESCRIPTION
Previously when using 32Thread+ systems, the libary would misparse the cores beyond the 32T threashold, causing bad behaviour.

This has now been fixed, with tests (and the parsing being moved to it's own testable sub-function)

Tested on a `12C*HT*2S`, `32C*HT`, and `32C*HT*2S` system's output on modern linux kernels